### PR TITLE
TRUST-1053 [skip ci]

### DIFF
--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -4,6 +4,7 @@ on: pull_request
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   TruffleHog:
@@ -14,7 +15,6 @@ jobs:
     env:
       BASE_REF: ${{ github.base_ref }}
       HEAD_REF: ${{ github.head_ref }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
@@ -32,7 +32,47 @@ jobs:
 
       - name: Trufflehog
         id: trufflehog
-        run: echo "TRUFFLEHOG_OUTPUT=$(trufflehog git file://. --since-commit "$FIRST_COMMIT" --branch "$HEAD_REF" --exclude-paths=.truffleignore --only-verified --json)" >> $GITHUB_ENV
+        run: |
+          TRUFFLEHOG_OUTPUT=""
+          capturefile=false
+          captureline=false
+          for finding in $(trufflehog git file://. --since-commit $FIRST_COMMIT --branch $HEAD_REF --only-verified); do
+              if [[ $capturefile == true ]] && [[ -z "$TRUFFLEHOG_OUTPUT" ]]; then
+              TRUFFLEHOG_OUTPUT="> - $finding"
+              elif [[ $capturefile == true ]] && [[ -n "$TRUFFLEHOG_OUTPUT" ]]; then
+              TRUFFLEHOG_OUTPUT="$TRUFFLEHOG_OUTPUT\n> - $finding"
+              fi
+              if [[ $captureline == true ]]; then
+              TRUFFLEHOG_OUTPUT="$TRUFFLEHOG_OUTPUT\#$finding"
+              fi
+              capturefile=false
+              captureline=false
+              if [[ "$finding" == "File:"* ]]; then
+              capturefile=true
+              elif [[ "$finding" == "Line:"* ]]; then
+              captureline=true
+              fi
+          done
+          echo "TRUFFLEHOG_OUTPUT=$TRUFFLEHOG_OUTPUT" >> $GITHUB_ENV
+
+      - name: Comment on PR
+        if: env.TRUFFLEHOG_OUTPUT != ''
+        id: comment
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        with:
+          github-token: ${{ secrets.BOBBY_TABLES_PAT }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body:`> [!WARNING]
+                \*\*TruffleHog has detected verified secrets in the following files:\*\*
+              \>
+              ${{ env.TRUFFLEHOG_OUTPUT }}
+              \>
+              \> _This pull request will remain blocked to prevent secrets from being merged in. Please contact @ncino/product-security or join [#help-product-security](https://ncino.slack.com/archives/C02G4R09NUU) for assistance._`
+            })
 
       - name: Send output to Slack if not empty
         if: env.TRUFFLEHOG_OUTPUT != ''


### PR DESCRIPTION
Batch rollout to add comment functionality to TruffleHog scans

[_Created by Sourcegraph batch change `jake/Add-trufflehog-comments`._](https://sourcegraph.hosted.ncino.com/users/jake/batch-changes/Add-trufflehog-comments)