### PR TITLE
TRUST-1077 [skip ci]

### DIFF
--- a/.github/.truffleignore
+++ b/.github/.truffleignore
@@ -1,3 +1,0 @@
-# This file should contain filepaths that should be ignored
-# during the trufflehog-scan workflow. Each filepath should
-# be on its own line of the file similar to a .gitignore.

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -36,7 +36,7 @@ jobs:
           TRUFFLEHOG_OUTPUT=""
           capturefile=false
           captureline=false
-          for finding in $(trufflehog git file://. --since-commit $FIRST_COMMIT --branch $HEAD_REF --exclude-paths=.github/.truffleignore --only-verified); do
+          for finding in $(trufflehog git file://. --since-commit $FIRST_COMMIT --branch $HEAD_REF --only-verified); do
               if [[ $capturefile == true ]] && [[ -z "$TRUFFLEHOG_OUTPUT" ]]; then
               TRUFFLEHOG_OUTPUT="> - $finding"
               elif [[ $capturefile == true ]] && [[ -n "$TRUFFLEHOG_OUTPUT" ]]; then


### PR DESCRIPTION
Remove .truffleignore files and update trufflehog scan workflow

[_Created by Sourcegraph batch change `garret/deprecate-truffleignore-files`._](https://sourcegraph.hosted.ncino.com/users/garret/batch-changes/deprecate-truffleignore-files)